### PR TITLE
Add back navigation and payment updates

### DIFF
--- a/app/src/main/java/com/onkar/projectx/HomeApiService.kt
+++ b/app/src/main/java/com/onkar/projectx/HomeApiService.kt
@@ -7,6 +7,7 @@ import com.onkar.projectx.data.HomeResponse
 import com.onkar.projectx.data.SubscriptionRequest
 import com.onkar.projectx.data.TokenResponse
 import com.onkar.projectx.data.UserDashboardResponse
+import com.onkar.projectx.data.PaymentType
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -53,6 +54,9 @@ interface HomeApiService {
         @Header("Authorization") token: String,
         @Body request: SubscriptionRequest
     ): Response<Unit>
+
+    @GET("api/payment/methods")
+    suspend fun getPaymentMethods(): List<PaymentType>
 }
 
 object ApiClient {

--- a/app/src/main/java/com/onkar/projectx/screens/PaymentScreen.kt
+++ b/app/src/main/java/com/onkar/projectx/screens/PaymentScreen.kt
@@ -55,7 +55,7 @@ fun PaymentScreen(navController: NavHostController, walletViewModel: WalletViewM
         } else {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 stickyHeader {
-                    TopViewBasic("Payment")
+                    TopViewBasic("Payment", navController)
                     AmountStickyHeader(amount)
                 }
 
@@ -73,15 +73,15 @@ fun AmountStickyHeader(amount: String) {
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surface)
-            .padding(16.dp),
-        tonalElevation = 4.dp,
-        shadowElevation = 2.dp
+            .padding(16.dp)
     ) {
-        Text(
-            text = "Recharge Amount: ₹$amount",
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onPrimary
-        )
+        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+            Text(
+                text = "Recharge Amount: ₹$amount",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/onkar/projectx/screens/WalletScreen.kt
+++ b/app/src/main/java/com/onkar/projectx/screens/WalletScreen.kt
@@ -38,10 +38,11 @@ import com.onkar.projectx.viewmodels.WalletViewModel
 @Composable
 fun WalletScreen(navController: NavHostController, walletViewModel: WalletViewModel) {
     Column(modifier = Modifier.fillMaxSize()) {
-        TopViewBasic("Wallet")
+        TopViewBasic("Wallet", navController)
         WalletView(modifier = Modifier.weight(1f), walletViewModel)
         Button(
             onClick = { navController.navigate(Screen.Payment.route) },
+            enabled = walletViewModel.amount.toDoubleOrNull()?.let { it > 0 } == true,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),

--- a/app/src/main/java/com/onkar/projectx/ui_components/UIComponents.kt
+++ b/app/src/main/java/com/onkar/projectx/ui_components/UIComponents.kt
@@ -43,6 +43,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -68,6 +69,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.SideEffect
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import coil.compose.AsyncImage
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.onkar.projectx.data.CalendarDay
@@ -300,17 +304,33 @@ fun QuantityStepper(
 }
 
 @Composable
-fun TopViewBasic(title: String) {
+fun TopViewBasic(title: String, navController: NavHostController? = null) {
     val colorScheme = MaterialTheme.colorScheme
+    val systemUiController = rememberSystemUiController()
+    SideEffect {
+        systemUiController.setStatusBarColor(colorScheme.surface, darkIcons = false)
+    }
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .background(colorScheme.surface) // Black background from theme
-            .padding(16.dp), verticalAlignment = Alignment.CenterVertically
+            .background(colorScheme.surface)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
+        if (navController != null) {
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(
+                    imageVector = Icons.Default.ArrowBack,
+                    contentDescription = "Back",
+                    tint = colorScheme.onSurface
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+        }
         Text(
-            text = title, color = colorScheme.onSurface, // White text on black background
+            text = title,
+            color = colorScheme.onSurface,
             style = MaterialTheme.typography.titleMedium
         )
     }

--- a/app/src/main/java/com/onkar/projectx/viewmodels/WalletViewModel.kt
+++ b/app/src/main/java/com/onkar/projectx/viewmodels/WalletViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.lifecycle.viewModelScope
+import com.onkar.projectx.ApiClient
 import com.onkar.projectx.data.PaymentMethod
 import com.onkar.projectx.data.PaymentType
 import kotlinx.coroutines.delay
@@ -30,7 +31,18 @@ class WalletViewModel : ViewModel() {
 
         isLoading = true
         viewModelScope.launch {
-            delay(1500) // Simulate API call
+            try {
+                val apiData = ApiClient.homeApi.getPaymentMethods()
+                if (apiData.isNotEmpty()) {
+                    _paymentTypes.addAll(apiData)
+                    isLoading = false
+                    return@launch
+                }
+            } catch (_: Exception) {
+                // ignore errors and fallback to demo data
+            }
+
+            delay(1500)
             _paymentTypes.addAll(
                 listOf(
                     PaymentType(


### PR DESCRIPTION
## Summary
- add new backend API endpoint for payment methods
- fetch payment methods from backend with fallback to demo data
- center payment amount header and match toolbar colors
- disable recharge if amount is zero and add back button on wallet screen
- update toolbar to include back navigation and set status bar color

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684bd250737c8323bff4f12c85a1b215