### PR TITLE
Add Search screen and integrate navigation

### DIFF
--- a/app/src/main/java/com/onkar/projectx/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/onkar/projectx/navigation/NavigationGraph.kt
@@ -24,6 +24,7 @@ import com.onkar.projectx.screens.LandingScreen
 import com.onkar.projectx.screens.MobileNumberScreen
 import com.onkar.projectx.screens.OTPScreen
 import com.onkar.projectx.screens.PLPScreen
+import com.onkar.projectx.screens.SearchScreen
 import com.onkar.projectx.screens.PaymentScreen
 import com.onkar.projectx.screens.ProductDetailScreen
 import com.onkar.projectx.screens.ProfileScreen
@@ -132,6 +133,14 @@ fun NavigationGraph(
             PLPScreen(
                 cartViewModel = cartViewModel,
                 navController = navController,
+                viewModel = productsViewModel
+            )
+        }
+
+        composable(Screen.Search.route) {
+            SearchScreen(
+                navController = navController,
+                cartViewModel = cartViewModel,
                 viewModel = productsViewModel
             )
         }

--- a/app/src/main/java/com/onkar/projectx/navigation/Screens.kt
+++ b/app/src/main/java/com/onkar/projectx/navigation/Screens.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.ui.graphics.vector.ImageVector
 
 sealed class Screen(val route: String, val icon: ImageVector, val title: String) {
@@ -15,6 +16,7 @@ sealed class Screen(val route: String, val icon: ImageVector, val title: String)
     object Reorder : Screen("reorder", Icons.Default.Call, "Reorder")
     object PLP : Screen("plp", Icons.Default.Home, "PLP")
     object Landing : Screen("landing", Icons.Default.Home, "Landing")
+    object Search : Screen("search", Icons.Default.Search, "Search")
 
 
     object ProductDetail : Screen("productDetail", Icons.Default.DateRange, "ProductDetail")
@@ -35,6 +37,7 @@ val hideBottomBarRoutes = listOf(
     Screen.OTP.route,
     Screen.ProductDetail.route,
     Screen.PLP.route,
+    Screen.Search.route,
     Screen.Landing.route
 )
 

--- a/app/src/main/java/com/onkar/projectx/screens/HomeScreen.kt
+++ b/app/src/main/java/com/onkar/projectx/screens/HomeScreen.kt
@@ -119,7 +119,7 @@ fun TopBanner(adjustedHeight: Dp, isLoading: Boolean = false) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            SearchBarView()
+            SearchBarView { navController.navigate(Screen.Search.route) }
         }
     }
 }

--- a/app/src/main/java/com/onkar/projectx/screens/PLPScreen.kt
+++ b/app/src/main/java/com/onkar/projectx/screens/PLPScreen.kt
@@ -99,7 +99,7 @@ fun PLPScreen(
                         )
                     }
 
-                    SearchBarView()
+                    SearchBarView { navController.navigate(Screen.Search.route) }
                 }
 
                 Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/com/onkar/projectx/screens/SearchScreen.kt
+++ b/app/src/main/java/com/onkar/projectx/screens/SearchScreen.kt
@@ -1,0 +1,87 @@
+package com.onkar.projectx.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.onkar.projectx.ui_components.PLPProductView
+import com.onkar.projectx.viewmodels.CartViewModel
+import com.onkar.projectx.viewmodels.ProductsViewModel
+
+@Composable
+fun SearchScreen(
+    navController: NavHostController,
+    cartViewModel: CartViewModel,
+    viewModel: ProductsViewModel
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    var query by remember { mutableStateOf("") }
+
+    val products = if (query.isBlank()) uiState.products else viewModel.searchProductsByName(query)
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.White)
+                .padding(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(
+                    imageVector = Icons.Default.ArrowBack,
+                    contentDescription = "Back",
+                    tint = Color.Black
+                )
+            }
+            TextField(
+                value = query,
+                onValueChange = { query = it },
+                placeholder = { Text("Search products") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        if (uiState.isLoading && uiState.products.isEmpty()) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        } else {
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                contentPadding = PaddingValues(4.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                items(products) { product ->
+                    PLPProductView(
+                        item = product,
+                        viewModel = viewModel,
+                        cartViewModel = cartViewModel,
+                        navController = navController
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/onkar/projectx/screens/SearchScreen.kt
+++ b/app/src/main/java/com/onkar/projectx/screens/SearchScreen.kt
@@ -36,7 +36,7 @@ fun SearchScreen(
     val uiState by viewModel.uiState.collectAsState()
     var query by remember { mutableStateOf("") }
 
-    val products = if (query.isBlank()) uiState.products else viewModel.searchProductsByName(query)
+    val products = if (query.isBlank()) uiState.products else viewModel.searchProducts(query)
 
     Column(modifier = Modifier.fillMaxSize()) {
         Row(

--- a/app/src/main/java/com/onkar/projectx/ui_components/UIComponents.kt
+++ b/app/src/main/java/com/onkar/projectx/ui_components/UIComponents.kt
@@ -589,7 +589,7 @@ fun PLPProductView(
 
 
 @Composable
-fun SearchBarView() {
+fun SearchBarView(onSearchClick: () -> Unit = {}) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -599,6 +599,7 @@ fun SearchBarView() {
             .border(
                 1.dp, color = Color.LightGray, shape = RoundedCornerShape(16.dp)
             )
+            .clickable { onSearchClick() }
             .padding(horizontal = 8.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {


### PR DESCRIPTION
## Summary
- implement `SearchScreen` composable to display a searchable product list
- make `SearchBarView` clickable so search can be triggered
- navigate to `SearchScreen` from Home and PLP screens
- register new `Search` route in navigation graph and screen list

## Testing
- `./gradlew test` *(fails: Unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_686610e20b848323854a08991aa149cc